### PR TITLE
Add option to download a whole playlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@ This repository now includes a Python script named `download_track.py` that allo
 To run the `download_track.py` script, you will need:
 - Python 3.6 or newer
 - `pytube` library installed (you can install it using `pip install pytube`)
+- `pytube` library version 10.0.0 or newer for playlist functionality
 
 ## Usage
 
 To download a track from Youtube Music, you can either run the script with the track's URL as an argument or enter the URL after the script starts:
 
 ```
-python download_track.py <YouTube Music track URL>
+python download_track.py track <YouTube Music track URL>
 ```
 
 Or, if you do not provide the URL as an argument, the script will prompt you to enter it:
@@ -25,7 +26,7 @@ python download_track.py
 For example, to download a specific track by providing the URL as an argument:
 
 ```
-python download_track.py https://www.youtube.com/watch?v=EXAMPLE
+python download_track.py track https://www.youtube.com/watch?v=EXAMPLE
 ```
 
 And if you run the script without an argument, it will ask:
@@ -35,3 +36,19 @@ Enter the YouTube Music track URL:
 ```
 
 This will download the specified track as an MP3 file to the current directory.
+
+## Downloading a Playlist
+
+To download an entire playlist from Youtube Music, use the `playlist` mode followed by the playlist's URL:
+
+```
+python download_track.py playlist <YouTube Music playlist URL>
+```
+
+For example, to download a whole playlist:
+
+```
+python download_track.py playlist https://www.youtube.com/playlist?list=EXAMPLE
+```
+
+This will download all tracks in the specified playlist as MP3 files to the current directory.

--- a/download_track.py
+++ b/download_track.py
@@ -1,6 +1,6 @@
 import os
 import sys  # Import sys module to access command line arguments
-from pytube import YouTube
+from pytube import YouTube, Playlist
 
 def download_track(url, save_path='./'):
     """
@@ -25,11 +25,47 @@ def download_track(url, save_path='./'):
     except Exception as e:
         print(f"Failed to download the track: {e}")
 
+def download_playlist(url, save_path='./'):
+    """
+    Downloads all tracks from a YouTube Music playlist as MP3 files.
+
+    Args:
+        url (str): The URL of the YouTube Music playlist to download.
+        save_path (str): The directory to save the downloaded MP3 files.
+    """
+    try:
+        # Create Playlist object with the URL
+        playlist = Playlist(url)
+
+        # Iterate over all video URLs in the playlist
+        for video_url in playlist.video_urls:
+            # Download each track using the existing function
+            download_track(video_url, save_path)
+
+        print(f"Downloaded all tracks from playlist successfully.")
+
+    except Exception as e:
+        print(f"Failed to download the playlist: {e}")
+
 if __name__ == "__main__":
     # Check if a URL is passed as a command line argument
-    if len(sys.argv) > 1:
-        url = sys.argv[1]  # Use the URL passed as command line argument
+    if len(sys.argv) > 2:
+        url = sys.argv[2]  # Use the URL passed as command line argument
+        mode = sys.argv[1]  # Determine mode (track or playlist)
+
+        if mode == "track":
+            download_track(url)
+        elif mode == "playlist":
+            download_playlist(url)
+        else:
+            print("Invalid mode. Use 'track' or 'playlist'.")
     else:
         # Only prompt for input if no URL is provided as a command line argument
-        url = input("Enter the YouTube Music track URL: ")
-    download_track(url)
+        mode = input("Enter mode (track/playlist): ")
+        url = input("Enter the YouTube Music URL: ")
+        if mode == "track":
+            download_track(url)
+        elif mode == "playlist":
+            download_playlist(url)
+        else:
+            print("Invalid mode. Use 'track' or 'playlist'.")


### PR DESCRIPTION
This pull request introduces the ability to download entire playlists from YouTube Music in addition to individual tracks.

- **New Functionality**: Adds a `download_playlist` function to `download_track.py` that takes a playlist URL and downloads all tracks within it as MP3 files.
- **Command Line Argument Handling**: Modifies the main block to accept an additional command line argument specifying the mode (`track` or `playlist`) and the corresponding URL. This allows users to choose between downloading a single track or an entire playlist.
- **README Updates**: Enhances the `README.md` file with instructions on how to download playlists, including the requirement for `pytube` library version 10.0.0 or newer and example commands for both tracks and playlists.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jcansdale/extract-mp3?shareId=bc28dd2e-d11e-4a77-b0b8-61c3f4178d41).