### PR TITLE
Fix ffprobe or avprobe not found issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ To run the `download_track.py` script, you will need:
 - `pytube` library installed (you can install it using `pip install pytube`)
 - `pytube` library version 10.0.0 or newer for playlist functionality
 - `pydub` library installed (you can install it using `pip install pydub`)
+- `ffmpeg` installed for handling audio conversions (you can install it using your system's package manager or download it from [FFmpeg's official website](https://ffmpeg.org/download.html))
 
 ## Usage
 
@@ -53,3 +54,7 @@ python download_track.py playlist https://www.youtube.com/playlist?list=EXAMPLE
 ```
 
 This will download all tracks in the specified playlist as MP4 files and then convert them to MP3 files using `pydub`, saving them to the current directory.
+
+## Troubleshooting
+
+If you encounter an error stating "Couldn't find ffprobe or avprobe - defaulting to ffprobe, but may not work", it indicates that `ffmpeg` is not properly installed or configured. Ensure that `ffmpeg` is installed on your system and that its binaries are in your system's PATH. For detailed installation instructions, refer to the [FFmpeg's official website](https://ffmpeg.org/download.html).

--- a/download_track.py
+++ b/download_track.py
@@ -2,6 +2,7 @@ import os
 import sys  # Import sys module to access command line arguments
 from pytube import YouTube, Playlist
 from pydub import AudioSegment  # Import AudioSegment from pydub
+from pydub.exceptions import CouldntDecodeError
 
 def download_track(url, save_path='./'):
     """
@@ -31,6 +32,8 @@ def download_track(url, save_path='./'):
 
         print(f"Downloaded and converted '{yt.title}' successfully.")
 
+    except CouldntDecodeError:
+        print("Failed to convert the track. Please ensure ffmpeg/ffprobe is installed and available in your PATH.")
     except Exception as e:
         print(f"Failed to download and convert the track: {e}")
 
@@ -53,6 +56,8 @@ def download_playlist(url, save_path='./'):
 
         print(f"Downloaded and converted all tracks from playlist successfully.")
 
+    except CouldntDecodeError:
+        print("Failed to convert one or more tracks in the playlist. Please ensure ffmpeg/ffprobe is installed and available in your PATH.")
     except Exception as e:
         print(f"Failed to download and convert the playlist: {e}")
 


### PR DESCRIPTION
This pull request addresses the issue of missing `ffprobe` or `avprobe` by updating the `README.md` and adding error handling in the `download_track.py` script.

- **README.md Updates:**
  - Adds instructions for installing `ffmpeg`, which includes `ffprobe`, in the "Requirements" section.
  - Introduces a "Troubleshooting" section that guides users on what to do if they encounter an error related to `ffprobe` or `avprobe` not being found.

- **Script Error Handling:**
  - Implements error handling in both `download_track` and `download_playlist` functions within `download_track.py` to catch `CouldntDecodeError`.
  - Prints a message advising the user to ensure `ffmpeg`/`ffprobe` is installed and available in their PATH if a `CouldntDecodeError` is caught.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jcansdale/extract-mp3?shareId=1da79225-e98a-4368-8122-bd06b76c4ff5).