### PR TITLE
Automate Docker image publishing to GitHub Container Registry

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,0 +1,30 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository }}/extract-mp3:latest

--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ docker run --rm -v $(pwd):/app extract-mp3 playlist <YouTube Music playlist URL>
 ```
 This will download the specified track or all tracks in the specified playlist as MP4 files and then convert them to MP3 files using `pydub`, saving them to the current directory.
 
+## Pulling the Docker Image from GitHub Container Registry
+
+To pull the Docker image from GitHub Container Registry, use the following command:
+
+```
+docker pull ghcr.io/<username>/extract-mp3:latest
+```
+
+Replace `<username>` with your GitHub username.
+
 ## Troubleshooting
 
 If you encounter an error stating "Couldn't find ffprobe or avprobe - defaulting to ffprobe, but may not work", it indicates that `ffmpeg` is not properly installed or configured. Ensure that `ffmpeg` is installed on your system and that its binaries are in your system's PATH. For detailed installation instructions, refer to the [FFmpeg's official website](https://ffmpeg.org/download.html).


### PR DESCRIPTION
This pull request introduces automation for publishing Docker images to GitHub Container Registry and updates the README.md with instructions on pulling the Docker image.

- **GitHub Actions Workflow**: Adds a new file `.github/workflows/publish-docker-image.yml` to automate the Docker image publishing process. This workflow triggers on push events to the main branch and tags starting with `v`. It includes steps for checking out the repository, logging into GitHub Container Registry, and building and pushing the Docker image to the registry.
- **README.md Update**: Enhances the Docker support section by adding instructions on how to pull the Docker image from GitHub Container Registry using the command `docker pull ghcr.io/<username>/extract-mp3:latest`, where `<username>` should be replaced with the user's GitHub username.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jcansdale/extract-mp3?shareId=1e7abaaf-52a5-4340-b62c-8daa0d906930).