### PR TITLE
Update workflow to include necessary permissions

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -7,6 +7,10 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  packages: write
+  contents: read
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Updates the GitHub Actions workflow to include specific permissions.

- Adds `permissions` settings for `packages: write` and `contents: read` in the `.github/workflows/publish-docker-image.yml` file, ensuring the workflow has the necessary permissions for its operations.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jcansdale/extract-mp3?shareId=21936250-a473-4224-beac-1aae81eff477).