### PR TITLE
Update README to use '.' instead of '$(pwd)'

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ docker build -t extract-mp3 .
 
 2. To download a track or playlist, run the Docker container with the necessary arguments, ensuring the working directory is `/downloads`:
 ```
-docker run -it --rm -v $(pwd):/downloads ghcr.io/jcansdale/extract-mp3 track 'https://music.youtube.com/watch?v=EXAMPLE'
+docker run -it --rm -v .:/downloads ghcr.io/jcansdale/extract-mp3 track 'https://music.youtube.com/watch?v=EXAMPLE'
 ```
 Or for a playlist:
 ```
-docker run -it --rm -v $(pwd):/downloads ghcr.io/jcansdale/extract-mp3 playlist 'https://music.youtube.com/playlist?list=EXAMPLE'
+docker run -it --rm -v .:/downloads ghcr.io/jcansdale/extract-mp3 playlist 'https://music.youtube.com/playlist?list=EXAMPLE'
 ```
 This will download the specified track or all tracks in the specified playlist as MP4 files and then convert them to MP3 files using `pydub`, saving them to the `/downloads` directory.
 


### PR DESCRIPTION
Updates the Docker run command in the README.md to use `.` instead of `$(pwd)` for mounting the current directory to `/downloads` in the container.
- Changes `$(pwd)` to `.` in the Docker run command examples for both track and playlist downloads, ensuring consistency and simplifying the command for users.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jcansdale/extract-mp3?shareId=591f3544-b8be-402c-a087-ef0d0af1a25b).