### PR TITLE
Integrate Azure container deployment into GitHub Actions

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -41,3 +41,16 @@ jobs:
           file: ./Dockerfile-flask
           push: true
           tags: ghcr.io/${{ github.repository }}-flask:latest
+
+  deploy-to-azure:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Azure
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Create Azure container instance
+        run: |
+          az container create --resource-group FlaskResourceGroup --name publish-image-azure --image ghcr.io/jcansdale/extract-mp3-flask:latest --dns-name-label publish-image-azure --ports 80


### PR DESCRIPTION
This pull request introduces a new job to the GitHub Actions workflow for deploying Docker images to Azure.

- **Adds a new job `deploy-to-azure`** to the `.github/workflows/publish-docker-image.yml` file, which is triggered after the `build-and-push` job completes successfully.
- **Utilizes `azure/login@v1` action** for Azure authentication within the `deploy-to-azure` job.
- **Executes the `az container create` command** to create an Azure container instance with the specified image and settings, as part of the `deploy-to-azure` job steps.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jcansdale/extract-mp3?shareId=959d40f2-d561-46a2-b8fc-fb0f09f85298).