### PR TITLE
Expand URL input field width

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -8,7 +8,7 @@
 <body>
     <h1>Enter YouTube Music Track URL to Download:</h1>
     <form action="/download" method="post">
-        <input type="text" name="url" required>
+        <input type="text" name="url" required style="width: 80%;">
         <input type="submit" value="Download">
     </form>
 </body>


### PR DESCRIPTION
Updates the URL input field width in the `index.html` template to improve usability.

- Sets the URL input field's width to 80% to allow for easier URL entry, enhancing the form's usability on various screen sizes.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jcansdale/extract-mp3?shareId=62c83205-922d-461e-a297-2ecc529d67d9).