### PR TITLE
Use pytubefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The setup process for Codespaces is now automated. When a codespace is created, 
 To run the `download_track.py` script, you will need:
 - Python 3.6 or newer
 - Install the required libraries using `pip install -r requirements.txt`. This will install:
-  - `pytube` library version 10.0.0 or newer for playlist functionality
+  - `pytubefix` library for playlist functionality
   - `pydub` library
 - `ffmpeg` installed for handling audio conversions. `ffmpeg` is not a Python package and needs to be installed separately. You can install it using your system's package manager or download it from [FFmpeg's official website](https://ffmpeg.org/download.html)
 

--- a/download_track.py
+++ b/download_track.py
@@ -1,6 +1,6 @@
 import os
 import sys  # Import sys module to access command line arguments
-from pytube import YouTube, Playlist
+from pytubefix import YouTube, Playlist
 from pydub import AudioSegment  # Import AudioSegment from pydub
 from pydub.exceptions import CouldntDecodeError
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pytube>=10.0.0
+pytubefix
 pydub
 # ffmpeg needs to be installed separately and is not a Python package.
 


### PR DESCRIPTION
Fixes #27

Replace `pytube` with `pytubefix` in the project.

* **requirements.txt**
  - Replace `pytube` with `pytubefix`.

* **download_track.py**
  - Import `YouTube` and `Playlist` from `pytubefix` instead of `pytube`.

* **README.md**
  - Update mentions of `pytube` to `pytubefix`.
  - Update the requirements section to reflect the use of `pytubefix`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jcansdale/extract-mp3/issues/27?shareId=6ce1f4f5-c896-4792-a5d2-aaf983b5560c).